### PR TITLE
Update dbg_example.c to match dbg.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dbg_example
 dbg_test
 dbg_test.c
 dbg_test.out
+*.o

--- a/dbg.3
+++ b/dbg.3
@@ -151,7 +151,6 @@
 .BI "void fwarn_or_err(int exitcode, FILE *stream, const char *name, bool warning, const char *fmt, ...);"
 .br
 .BI "void vfwarn_or_err(int exitcode, FILE *stream, const char *name, bool warning, const char *fmt, va_list ap);"
-.RE
 .SH DESCRIPTION
 These functions provide a way to write informative messages, debug messages, warning messages, error messages, non\-fatal error messages as well as usage messages.
 .SS Alternative output \fBFILE *\fP stream
@@ -293,7 +292,7 @@ do not return if warning is false in the same manner as the functions
 .BR verrp(),
 .BR ferrp(),
 and
-.BR vferrp()
+.BR vferrp().
 .PP
 The functions
 .BR printf_usage(),

--- a/dbg_example.c
+++ b/dbg_example.c
@@ -1,19 +1,23 @@
 /*
- * This is just a trivial demo, see the main
- * function in dbg.c for a better example.
+ * This is just a trivial demo for the dbg api, see the main function in dbg.c
+ * for a better example.
  */
 
 #include "dbg.h"
 
 #define filename "foo.bar"
+
 long length = 7;
-int main(void)
+
+int
+main(void)
 {
 
     /*
      * We suggest you use getopt(3) and strtol(3) (cast to an int)
      * to convert -v verbosity_level on the command line.
      */
+    msg("NOTE: Setting verbosity_level to DBG_MED: %d", DBG_MED);
     verbosity_level = DBG_MED; /* DBG_MED == (3) */
 
     /*
@@ -23,7 +27,8 @@ int main(void)
      *
      * with newlines as described.
      */
-    warn(__func__, "elephant is sky-blue pink");
+    msg("NOTE: The next line should say: \"Warning: %s: %s", __func__, "elephant is sky-blue pink\"");
+    warn(__func__, "elephant is sky-blue pink\n");
 
     /* this will not print anything as verbosity_level 3 (DBG_MED) < 5 (DBG_HIGH): */
     dbg(DBG_HIGH, "starting critical section");
@@ -34,7 +39,8 @@ int main(void)
      *
      *	    debug[3]: file: foo.bar has length: 7
      */
-    dbg(DBG_MED, "file: %s has length: %ld", filename, length);
+    msg("NOTE: The next line should read: \"debug[3]: file: %s has length: %ld\"", filename, length);
+    dbg(DBG_MED, "file: %s has length: %ld\n", filename, length);
 
     /*
      * If EPERM == 1 then this will print:
@@ -44,5 +50,8 @@ int main(void)
      * with newlines as discussed and then exit 2.
      */
     errno = EPERM;
+    msg("NOTE: The next line should read: \"ERROR[2]: main: test: errno[%d]: %s\"", errno, strerror(errno));
     errp(2, __func__, "test");
+
+    return 2; /* this return is never reached */
 }


### PR DESCRIPTION
Due to more than one person working on this repo and apparently my
updates to dbg.3 being updated here without the dbg_example.c being
updated this commit makes dbg_example.c be the same as in dbg.3 as it
should have been in the first place (this happened as I was having a
problem with my fork).

Now dbg_example.c shows what the next line should be so that the user
can verify that it works properly.

I also added a missing full stop in a functions list in dbg.3.

As well I removed a .RE from dbg.3 that did not have a matching .RS
(and does not need one).