### PR TITLE
Fix - to \- in man page

### DIFF
--- a/dbg.3
+++ b/dbg.3
@@ -1,4 +1,4 @@
-.TH dbg 3  "1 July 2022" "dbg"
+.TH dbg 3  "18 October 2022" "dbg"
 .SH NAME
 .BR msg(),
 .BR vmsg(),
@@ -433,8 +433,8 @@ The above two commands could be shortened to just:
 \fBcc \-o dbg_example dbg_example.c dbg.c\fP
 $ ./dbg_example
 NOTE: Setting verbosity_level to DBG_MED: 3
-NOTE: The next line should say: "Warning: main: elephant is sky-blue pink"
-Warning: main: elephant is sky-blue pink
+NOTE: The next line should say: "Warning: main: elephant is sky\-blue pink"
+Warning: main: elephant is sky\-blue pink
 
 NOTE: The next line should read: "debug[3]: file: foo.bar has length: 7"
 debug[3]: file: foo.bar has length: 7


### PR DESCRIPTION
Because I could not think of a way at this hour with such poor sleep to do it directly I just removed \ before all '-'s and then added them back like:

    sed -i -e 's/\\-/-/g' -e 's/-/\\-/g' dbg.3

I then updated the date of the man page. This was started because of a mkiocccentry commit ce061e0e160004d2de7d8e5fd145bcb79ab7eb48:

    Made -h, -V and other -option in man pages consistent

    We are NOT sure of this is the best way, but
    when a -option is mentioned in the EXIT STATUS section
    of the man page, we put a \ in front of it.

    Example:

    \-h and help string printed or \-V and version string printed

That is indeed the correct way. I fix them as I notice them but this time I just did a mass replace (though in this case there was only one place it was not done).