### PR TITLE
Fix obscure bug with bool typedef

### DIFF
--- a/dbg.h
+++ b/dbg.h
@@ -47,7 +47,9 @@
 /*
  * standard truth :-)
  */
-#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)
+#if !defined(BOOL_IS_DEFINED)
+#define BOOL_IS_DEFINED
+#if !defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)
 /* have a C99 compiler - we should expect to have <stdbool.h> */
 #include <stdbool.h>
 #elif !defined(__cplusplus)
@@ -57,6 +59,7 @@ typedef unsigned char bool;
 #define true ((bool)(1))
 #undef false
 #define false ((bool)(0))
+#endif
 #endif
 /* booltostr - convert a boolean to a string */
 #if !defined(booltostr)


### PR DESCRIPTION
In the mkiocccentry repo the bug was filed in issue #417. The solution involved an ifdef guard in amongst other files dbg.h so the copy in this repo has to be modified as well. The description below explains it in the context of the mkiocccentry repo but the short of it is simply that depending on the set up of inclusions (which is indeterministic because each project is different) the typedef unsigned char bool could be a problem as shown below.

    The problem as reported is that under some systems running make clobber
    all test would result in a compilation error:

	In file included from jnum_test.c:26:0:
	../dbg/dbg.h:55:23: error: two or more data types in declaration specifiers
	 typedef unsigned char bool;
			       ^
	In file included from ../dyn_array.h:52:0,
			 from ../util.h:42,
			 from ../json_parse.h:26,
			 from jnum_test.c:33:
	../dbg/dbg.h:55:1: warning: useless type name in empty declaration [enabled by default]
	 typedef unsigned char bool;
	 ^
	In file included from jnum_test.c:26:0:
	../util.h:53:23: error: two or more data types in declaration specifiers
	 typedef unsigned char bool;
			       ^
	In file included from ../json_parse.h:26:0,
			 from jnum_test.c:33:
	../util.h:53:1: warning: useless type name in empty declaration [enabled by default]
	 typedef unsigned char bool;
	 ^
	make[1]: *** [jnum_test.o] Error 1
	make[1]: Leaving directory `/var/tmp/mkiocccentry/test_ioccc'
	make: *** [test] Error 2

    This is because bool was already defined and so the 'typedef unsigned
    char bool;' was a problem. The solution is in a number of files add an
    ifdef guard so that bool is only defined once - either from #including
    stdbool.h or from the typedef. Also as for util.h we have to move the
    inclusion of dyn_array.h so that it's below the boolean define as
    otherwise we will get another issue in some systems.

    This commit involves changes to some files that will possibly require
    changes elsewhere - iocccsize.h (which I won't touch normally) and dbg.h
    (which I'll do a pull request in the dbg repo).