### PR TITLE
Make linking man pages symlinks instead of .so

### DIFF
--- a/man/man3/errp.3
+++ b/man/man3/errp.3
@@ -1,1 +1,1 @@
-.so man3/err.3
+err.3

--- a/man/man3/fdbg.3
+++ b/man/man3/fdbg.3
@@ -1,1 +1,1 @@
-.so man3/dbg.3
+dbg.3

--- a/man/man3/ferr.3
+++ b/man/man3/ferr.3
@@ -1,1 +1,1 @@
-.so man3/err.3
+err.3

--- a/man/man3/ferrp.3
+++ b/man/man3/ferrp.3
@@ -1,1 +1,1 @@
-.so man3/err.3
+err.3

--- a/man/man3/fmsg.3
+++ b/man/man3/fmsg.3
@@ -1,1 +1,1 @@
-.so man3/msg.3
+msg.3

--- a/man/man3/fprintf_usage.3
+++ b/man/man3/fprintf_usage.3
@@ -1,1 +1,1 @@
-.so man3/printf_usage.3
+printf_usage.3

--- a/man/man3/fwarn.3
+++ b/man/man3/fwarn.3
@@ -1,1 +1,1 @@
-.so man3/warn.3
+warn.3

--- a/man/man3/fwarn_or_err.3
+++ b/man/man3/fwarn_or_err.3
@@ -1,1 +1,1 @@
-.so man3/warn_or_err.3
+warn_or_err.3

--- a/man/man3/fwarnp.3
+++ b/man/man3/fwarnp.3
@@ -1,1 +1,1 @@
-.so man3/warn.3
+warn.3

--- a/man/man3/fwerr.3
+++ b/man/man3/fwerr.3
@@ -1,1 +1,1 @@
-.so man3/werr.3
+werr.3

--- a/man/man3/fwerrp.3
+++ b/man/man3/fwerrp.3
@@ -1,1 +1,1 @@
-.so man3/werr.3
+werr.3

--- a/man/man3/sndbg.3
+++ b/man/man3/sndbg.3
@@ -1,1 +1,1 @@
-.so man3/dbg.3
+dbg.3

--- a/man/man3/snmsg.3
+++ b/man/man3/snmsg.3
@@ -1,1 +1,1 @@
-.so man3/msg.3
+msg.3

--- a/man/man3/snwarn.3
+++ b/man/man3/snwarn.3
@@ -1,1 +1,1 @@
-.so man3/warn.3
+warn.3

--- a/man/man3/snwarnp.3
+++ b/man/man3/snwarnp.3
@@ -1,1 +1,1 @@
-.so man3/warn.3
+warn.3

--- a/man/man3/snwerr.3
+++ b/man/man3/snwerr.3
@@ -1,1 +1,1 @@
-.so man3/werr.3
+werr.3

--- a/man/man3/snwerrp.3
+++ b/man/man3/snwerrp.3
@@ -1,1 +1,1 @@
-.so man3/werr.3
+werr.3

--- a/man/man3/vdbg.3
+++ b/man/man3/vdbg.3
@@ -1,1 +1,1 @@
-.so man3/dbg.3
+dbg.3

--- a/man/man3/verr.3
+++ b/man/man3/verr.3
@@ -1,1 +1,1 @@
-.so man3/err.3
+err.3

--- a/man/man3/verrp.3
+++ b/man/man3/verrp.3
@@ -1,1 +1,1 @@
-.so man3/err.3
+err.3

--- a/man/man3/vfdbg.3
+++ b/man/man3/vfdbg.3
@@ -1,1 +1,1 @@
-.so man3/dbg.3
+dbg.3

--- a/man/man3/vferr.3
+++ b/man/man3/vferr.3
@@ -1,1 +1,1 @@
-.so man3/err.3
+err.3

--- a/man/man3/vferrp.3
+++ b/man/man3/vferrp.3
@@ -1,1 +1,1 @@
-.so man3/err.3
+err.3

--- a/man/man3/vfmsg.3
+++ b/man/man3/vfmsg.3
@@ -1,1 +1,1 @@
-.so man3/msg.3
+msg.3

--- a/man/man3/vfprintf_usage.3
+++ b/man/man3/vfprintf_usage.3
@@ -1,1 +1,1 @@
-.so man3/printf_usage.3
+printf_usage.3

--- a/man/man3/vfwarn.3
+++ b/man/man3/vfwarn.3
@@ -1,1 +1,1 @@
-.so man3/warn.3
+warn.3

--- a/man/man3/vfwarn_or_err.3
+++ b/man/man3/vfwarn_or_err.3
@@ -1,1 +1,1 @@
-.so man3/warn_or_err.3
+warn_or_err.3

--- a/man/man3/vfwarnp.3
+++ b/man/man3/vfwarnp.3
@@ -1,1 +1,1 @@
-.so man3/warn.3
+warn.3

--- a/man/man3/vfwerr.3
+++ b/man/man3/vfwerr.3
@@ -1,1 +1,1 @@
-.so man3/werr.3
+werr.3

--- a/man/man3/vfwerrp.3
+++ b/man/man3/vfwerrp.3
@@ -1,1 +1,1 @@
-.so man3/werr.3
+werr.3

--- a/man/man3/vmsg.3
+++ b/man/man3/vmsg.3
@@ -1,1 +1,1 @@
-.so man3/msg.3
+msg.3

--- a/man/man3/vprintf_usage.3
+++ b/man/man3/vprintf_usage.3
@@ -1,1 +1,1 @@
-.so man3/printf_usage.3
+printf_usage.3

--- a/man/man3/vsndbg.3
+++ b/man/man3/vsndbg.3
@@ -1,1 +1,1 @@
-.so man3/dbg.3
+dbg.3

--- a/man/man3/vsnmsg.3
+++ b/man/man3/vsnmsg.3
@@ -1,1 +1,1 @@
-.so man3/msg.3
+msg.3

--- a/man/man3/vsnwarn.3
+++ b/man/man3/vsnwarn.3
@@ -1,1 +1,1 @@
-.so man3/warn.3
+warn.3

--- a/man/man3/vsnwarnp.3
+++ b/man/man3/vsnwarnp.3
@@ -1,1 +1,1 @@
-.so man3/warn.3
+warn.3

--- a/man/man3/vsnwerr.3
+++ b/man/man3/vsnwerr.3
@@ -1,1 +1,1 @@
-.so man3/werr.3
+werr.3

--- a/man/man3/vsnwerrp.3
+++ b/man/man3/vsnwerrp.3
@@ -1,1 +1,1 @@
-.so man3/werr.3
+werr.3

--- a/man/man3/vwarn.3
+++ b/man/man3/vwarn.3
@@ -1,1 +1,1 @@
-.so man3/warn.3
+warn.3

--- a/man/man3/vwarn_or_err.3
+++ b/man/man3/vwarn_or_err.3
@@ -1,1 +1,1 @@
-.so man3/warn_or_err.3
+warn_or_err.3

--- a/man/man3/vwarnp.3
+++ b/man/man3/vwarnp.3
@@ -1,1 +1,1 @@
-.so man3/warn.3
+warn.3

--- a/man/man3/vwerr.3
+++ b/man/man3/vwerr.3
@@ -1,1 +1,1 @@
-.so man3/werr.3
+werr.3

--- a/man/man3/vwerrp.3
+++ b/man/man3/vwerrp.3
@@ -1,1 +1,1 @@
-.so man3/werr.3
+werr.3

--- a/man/man3/warnp.3
+++ b/man/man3/warnp.3
@@ -1,1 +1,1 @@
-.so man3/warn.3
+warn.3

--- a/man/man3/werrp.3
+++ b/man/man3/werrp.3
@@ -1,1 +1,1 @@
-.so man3/werr.3
+werr.3


### PR DESCRIPTION
In other words instead of using .so man3/foo.3 it is just a symlink. This way running man on the file when it's not installed will work.