### PR TITLE
Add parse_verbosity(3) to API

### DIFF
--- a/dbg.c
+++ b/dbg.c
@@ -43,13 +43,13 @@
  * IMPORTANT WARNING: This code is widely used by a number of applications. A
  *		      great deal of care has gone in to making these debugging
  *		      facilities easy to code with, and much less likely to be
- *		      the source (pun intended) of bugs.
+ *		      the source (pun intended, obviously :-) ) of bugs.
  *
  *		      We apologize in advance for any problems this code may
  *		      introduce. We would be happy to fix a general bug by
  *		      considering a pull request to the dbg repo.
  *
- * DBG repo: https://github.com/lcn2/dbg
+ * dbg repo: https://github.com/lcn2/dbg
  *
  *		      You may also report a bug in the form of an issue using
  *		      the above URL.
@@ -6261,6 +6261,39 @@ vfprintf_usage(int exitcode, FILE *stream, char const *fmt, va_list ap)
 	errno = saved_errno;
     }
     return;
+}
+
+/*
+ * parse_verbosity - parse -v option for our tools
+ *
+ * given:
+ *	program		- the calling program e.g. txzchk, fnamchk, mkiocccentry etc.
+ *	arg		- the optarg in the calling tool
+ *
+ * Returns the parsed verbosity.
+ *
+ * Returns DBG_NONE if passed NULL args or empty string.
+ */
+int
+parse_verbosity(char const *program, char const *arg)
+{
+    int verbosity;
+
+    if (program == NULL || arg == NULL || !strlen(arg)) {
+	return DBG_NONE;
+    }
+
+    /*
+     * parse verbosity
+     */
+    errno = 0;		/* pre-clear errno for errp() */
+    verbosity = (int)strtol(arg, NULL, 0);
+    if (errno != 0) {
+	errp(3, __func__, "%s: cannot parse -v arg: %s error: %s", program, arg, strerror(errno)); /*ooo*/
+	not_reached();
+    }
+
+    return verbosity;
 }
 
 

--- a/dbg.h
+++ b/dbg.h
@@ -258,5 +258,6 @@ extern void fprintf_usage(int exitcode, FILE *stream, const char *fmt, ...) \
 	__attribute__((format(printf, 3, 4)));		/* 3=format 4=params */
 extern void vfprintf_usage(int exitcode, FILE *stream, char const *fmt, va_list ap);
 
+extern int parse_verbosity(char const *program, char const *arg);
 
 #endif				/* INCLUDE_DBG_H */

--- a/dbg.h
+++ b/dbg.h
@@ -41,7 +41,7 @@
 /*
  * definitions
  */
-#define DBG_VERSION "2.10 2023-08-01"		/* format: major.minor YYYY-MM-DD */
+#define DBG_VERSION "2.11 2023-08-02"		/* format: major.minor YYYY-MM-DD */
 
 
 /*

--- a/dbg_example.c
+++ b/dbg_example.c
@@ -1,7 +1,7 @@
 /*
  * dbg_example.c - trivial demo
  *
- * This is just a trivial demo for the dbg api.  See the main function in dbg.c
+ * This is just a trivial demo for the dbg API.  See the main function in dbg.c
  * for a more complete example.
  *
  * Written in 2022 by:
@@ -35,8 +35,10 @@ main(void)
 {
 
     /*
-     * We suggest you use getopt(3) and strtol(3) (cast to an int)
-     * to convert -v verbosity_level on the command line.
+     * We suggest you use getopt(3) and the parse_verbosity(3) function to
+     * convert -v verbosity_level on the command line like:
+     *
+     *	    verbosity_level = parse_verbosity(argv[0], optarg);
      */
     msg("NOTE: Setting verbosity_level to DBG_MED: %d", DBG_MED);
     verbosity_level = DBG_MED; /* DBG_MED == (3) */

--- a/man/man3/dbg.3
+++ b/man/man3/dbg.3
@@ -12,14 +12,15 @@
 .\" "Share and Enjoy!"
 .\"     --  Sirius Cybernetics Corporation Complaints Division, JSON spec department. :-)
 .\"
-.TH dbg 3  "05 February 2023" "dbg"
+.TH dbg 3  "02 August 2023" "dbg"
 .SH NAME
 .BR dbg() \|,
 .BR vdbg() \|,
 .BR fdbg() \|,
 .BR vfdbg() \|,
 .BR sndbg() \|,
-.BR vsndbg()
+.BR vsndbg() \|,
+.BR parse_verbosity()
 \- debug message facility
 .SH SYNOPSIS
 \fB#include "dbg.h"\fP
@@ -31,6 +32,8 @@
 .B "extern int verbosity_level;		/* maximum debug level for debug messages */"
 .br
 .B "extern bool dbg_output_allowed;		/* false ==> disable debug messages */"
+.br
+.B "int parse_verbosity(char const *program, char const *arg);"
 .sp
 .B "void dbg(int level, const char *fmt, ...);"
 .br
@@ -49,6 +52,33 @@ These functions provide a way to write debug messages to a stream such as
 or to a
 .B char *
 of a fixed size.
+The messages will not be written unless the boolean
+.B dbg_output_allowed
+is true and the verbosity (debug) level is high enough.
+To parse the verbosity level you can use the function
+.BR parse_verbosity (3).
+.PP
+The general call semantics of the
+.BR dbg (3)
+functions is passing in a debug level, a format string and any format args.
+The other versions are similar except that they take additional args as well, depending on the family.
+See below subsections for details.
+.SS Parsing verbosity level
+We provide a function
+.BR parse_verbosity (3)
+to let you easily parse the verbosity level in your programs.
+The function returns an
+.BR int ,
+which you can assign to the variable
+.BR verbosity_level ,
+and takes the parameters
+.BR program ,
+the name of the program, and
+.BR arg ,
+the option argument to the option you choose for verbosity.
+We choose
+.B \-v
+but you can choose whichever you wish.
 .SS Alternative output \fBFILE *\fP stream
 The functions that do not take a
 .B FILE *
@@ -194,8 +224,10 @@ main(void)
 {
 
     /*
-     * We suggest you use getopt(3) and strtol(3) (cast to an int)
-     * to convert \-v verbosity_level on the command line.
+     * We suggest you use getopt(3) and the parse_verbosity(3) function to
+     * convert \-v verbosity_level on the command line like:
+     *
+     *	    verbosity_level = parse_verbosity(argv[0], optarg);
      */
     msg("NOTE: Setting verbosity_level to DBG_MED: %d", DBG_MED);
     verbosity_level = DBG_MED; /* DBG_MED == (3) */


### PR DESCRIPTION
Since the debug facility is the one that uses a verbosity_level I have added the function that I added to the mkiocccentry repo util.c file (under jparse/util.c) to the dbg.c API.

The dbg.3 man page has been updated with this and also some other improvements. There is a recursive reference to the man page for parse_verbosity(3) in the man page just for fun.

The dbg related changes will be added to the mkiocccentry repo so that these changes are synchronised to that repo.

The dbg_example.c file that I wrote for this repo and the mkiocccentry repo (initially) has also been updated with a comment change, referring to not strtol(3) but rather the parse_verbosity(3) function.