### PR TITLE
Rename dbg.a libdbg.a

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,7 +261,7 @@ DEST_DIR= /usr/local/bin
 EXTERN_H= dbg.h
 EXTERN_O= dbg.o
 EXTERN_MAN= ${ALL_MAN_TARGETS}
-EXTERN_LIBA= dbg.a
+EXTERN_LIBA= libdbg.a
 EXTERN_PROG= dbg_example dbg_test
 
 # NOTE: ${EXTERN_CLOBBER} used outside of this directory and removed by make clobber
@@ -282,7 +282,7 @@ ALL_MAN_TARGETS= ${MAN1_TARGETS} ${MAN3_TARGETS} ${MAN8_TARGETS}
 
 # libraries to make by all, what to install, and removed by clobber
 #
-LIBA_TARGETS= dbg.a
+LIBA_TARGETS= libdbg.a
 
 # shell targets to make by all and removed by clobber
 #
@@ -348,7 +348,7 @@ all: ${TARGETS}
 dbg.o: dbg.c
 	${CC} ${CFLAGS} dbg.c -c
 
-dbg.a: ${LIB_OBJS}
+libdbg.a: ${LIB_OBJS}
 	${RM} -f $@
 	${AR} -r -u -v $@ $^
 	${RANLIB} $@
@@ -360,14 +360,14 @@ dbg_test.c: dbg.c
 dbg_test.o: dbg_test.c
 	${CC} ${CFLAGS} -DDBG_TEST dbg_test.c -c
 
-dbg_test: dbg_test.o dbg.a
-	${CC} ${CFLAGS} dbg_test.o dbg.a -o $@
+dbg_test: dbg_test.o libdbg.a
+	${CC} ${CFLAGS} dbg_test.o libdbg.a -o $@
 
 dbg_example.o: dbg_example.c
 	${CC} ${CFLAGS} dbg_example.c -c
 
-dbg_example: dbg_example.o dbg.a
-	${CC} ${CFLAGS} dbg_example.o dbg.a -o $@
+dbg_example: dbg_example.o
+	${CC} ${CFLAGS} dbg_example.o libdbg.a -o $@
 
 
 #########################################################

--- a/Makefile
+++ b/Makefile
@@ -361,13 +361,13 @@ dbg_test.o: dbg_test.c
 	${CC} ${CFLAGS} -DDBG_TEST dbg_test.c -c
 
 dbg_test: dbg_test.o libdbg.a
-	${CC} ${CFLAGS} dbg_test.o libdbg.a -o $@
+	${CC} ${CFLAGS} dbg_test.o -L. -ldbg -o $@
 
 dbg_example.o: dbg_example.c
 	${CC} ${CFLAGS} dbg_example.c -c
 
 dbg_example: dbg_example.o
-	${CC} ${CFLAGS} dbg_example.o libdbg.a -o $@
+	${CC} ${CFLAGS} dbg_example.o -L. -ldbg -o $@
 
 
 #########################################################

--- a/README.md
+++ b/README.md
@@ -39,15 +39,40 @@ levels of verbosity.
 
 # Set up
 
-1. Compile `dbg.c` to produce `dbg.o`.
+For more information and an example see the [dbg API](#dbg-api) section.
+
+## If you do not wish to install the library:
+
+0. Compile `dbg.c` to produce `dbg.o`.
 2. Add `#include "dbg.h"` to the C source files that you wish to use one or more
    of the `dbg` functions in.
-3. Set `verbosity_level` to some verbosity level such as `DBG_LOW` (1) or
+2. Set `verbosity_level` to some verbosity level such as `DBG_LOW` (1) or
    `DBG_MED` (3) (see `dbg.h` for other levels).
-4. Compile your source file(s) and link in `dbg.o`.
+3. Compile your source file(s) and link in `dbg.o`.
 
 
-For more information including an example see the next section.
+## Installing the library:
+
+First, compile the library:
+
+```sh
+    make clobber all
+```
+
+Next, install the library (as root or via sudo):
+
+```sh
+    make install
+```
+
+Then, set up the code kind of like above, but with these changes:
+
+0. Add `#include <dbg.h>` to the C source files that you wish to use one or more
+of the `dbg` functions in.
+1. Set the `verbosity_level` to some verbosity level such as `DBG_LOW` (1) or
+`DBG_MED` (3) (see `dbg.h` for other levels and the example further below).
+2. Compile your source file(s) and link in `libdbg.a` (e.g. pass to the compiler
+`-ldbg`).
 
 
 # The dbg API


### PR DESCRIPTION
To allow for linking in this library from say /usr/local/lib the library file has to be renamed to /usr/local/libdbg.a. This is a linker implementation detail. We need to have the ability to link in the dbg API in the jparse repo (https://github.com/xexyl/jparse) and this now is easier to link in and thus use the library.

The README.md set up instructions have two ways now: first what already existed, the set up of the library if you do not wish to install it and now the second, how to do it if you wish to install it.

For jparse another library needs this change which will be done after this, though possibly not right away.