### PR TITLE
Improve Makefile (install, uninstall)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,11 +107,36 @@ endif
 I=
 #I= @
 
+# installing variables
+#
+
 # INSTALL_V=				install w/o -v flag (quiet mode)
 # INSTALL_V= -v				install with -v (debug / verbose mode
 #
 #INSTALL_V=
 INSTALL_V= -v
+
+# where to install
+#
+# Default PREFIX is /usr/local so binaries would be installed in /usr/local/bin,
+# libraries in /usr/local/lib etc. If one wishes to override this, say
+# installing to /usr, they can do so like:
+#
+#	make PREFIX=/usr install
+#
+PREFIX= /usr/local
+
+# uninstalling variables
+#
+
+# RM_V=					rm w/o -v flag (quiet mode)
+# RM_V= -v				rm with -v (debug / verbose mode)
+#
+#RM_V=
+RM_V= -v
+
+# Additional controls
+#
 
 # MAKE_CD_Q= --no-print-directory	silence make cd messages (quiet mode)
 # MAKE_CD_Q=				silence make cd messages (quiet mode)
@@ -249,12 +274,12 @@ ALL_MAN_BUILT= ${MAN1_BUILT} ${MAN3_BUILT} ${MAN8_BUILT}
 
 # where to install
 #
-MAN1_DIR= /usr/local/share/man/man1
-MAN3_DIR= /usr/local/share/man/man3
-MAN8_DIR= /usr/local/share/man/man8
-DEST_INCLUDE= /usr/local/include
-DEST_LIB= /usr/local/lib
-DEST_DIR= /usr/local/bin
+MAN1_DIR= ${PREFIX}/share/man/man1
+MAN3_DIR= ${PREFIX}/share/man/man3
+MAN8_DIR= ${PREFIX}/share/man/man8
+DEST_INCLUDE= ${PREFIX}/include
+DEST_LIB= ${PREFIX}/lib
+DEST_DIR= ${PREFIX}/bin
 
 
 #################################
@@ -661,6 +686,66 @@ install: all install_man
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"
 
+uninstall:
+	${S} echo
+	${S} echo "${OUR_NAME}: make $@ starting"
+	${S} echo
+	${I} ${RM} -r -f ${RM_V} ${DEST_LIB}/libdbg.a
+
+	${RM} -r -f ${RM_V} ${DEST_DIR}/dbg_example
+	${RM} -r -f ${RM_V} ${DEST_DIR}/dbg_test
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/dbg.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/err.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/msg.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/warn.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/werr.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/printf_usage.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/warn_or_err.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/errp.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/fdbg.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/ferr.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/ferrp.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/fmsg.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/fprintf_usage.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/fwarn.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/fwarn_or_err.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/fwarnp.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/fwerr.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/fwerrp.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/sndbg.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/snmsg.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/snwarn.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/snwarnp.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/snwerr.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/snwerrp.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/vdbg.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/verr.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/verrp.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/vfdbg.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/vferr.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/vferrp.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/vfmsg.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/vfprintf_usage.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/vfwarn.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/vfwarn_or_err.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/vfwarnp.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/vfwerr.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/vfwerrp.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/vmsg.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/vprintf_usage.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/vsndbg.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/vsnmsg.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/vsnwarn.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/vsnwarnp.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/vsnwerr.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/vsnwerrp.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/vwarn.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/vwarn_or_err.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/vwarnp.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/vwerr.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/vwerrp.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/warnp.3
+	${RM} -r -f ${RM_V} ${MAN3_DIR}/werrp.3
 
 ###############
 # make depend #

--- a/Makefile
+++ b/Makefile
@@ -181,9 +181,13 @@ WARN_FLAGS= -pedantic -Wall -Wextra -Wno-char-subscripts
 #
 C_SPECIAL=
 
+# special linker flags
+#
+LD_SPECIAL=
+
 # linker options
 #
-LDFLAGS=
+LDFLAGS= ${LD_SPECIAL}
 
 # how to compile
 #

--- a/README.md
+++ b/README.md
@@ -14,6 +14,30 @@ make clobber all test
 sudo make install
 ```
 
+If you wish to install to another directory prefix, say to `/usr` instead of the
+default `/usr/local`, you can override it by specifying the `PREFIX` variable:
+
+```sh
+sudo make PREFIX=/usr install
+```
+
+
+## TL;DR Uninstall dbg
+
+If you wish to uninstall the programs, library and man pages, you can do so
+like:
+
+```sh
+sudo make uninstall
+```
+
+If you specified a different `PREFIX` when installing you'll have to specify
+that `PREFIX`. For instance if you installed to `/usr`:
+
+```sh
+sudo make PREFIX=/usr uninstall
+```
+
 
 # dbg - info, debug, warning, error and usage message facility
 
@@ -65,6 +89,16 @@ Next, install the library (as root or via sudo):
     make install
 ```
 
+If you wish to change the `PREFIX`, say to `/usr` instead of `/usr/local`, you
+can do so like:
+
+```sh
+make PREFIX=/usr install
+```
+
+as root or via sudo.
+
+
 Then, set up the code kind of like above, but with these changes:
 
 0. Add `#include <dbg.h>` to the C source files that you wish to use one or more
@@ -73,6 +107,27 @@ of the `dbg` functions in.
 `DBG_MED` (3) (see `dbg.h` for other levels and the example further below).
 2. Compile your source file(s) and link in `libdbg.a` (e.g. pass to the compiler
 `-ldbg`).
+
+
+# Uninstalling
+
+If you're tired of bugs :-) you can uninstall the programs, library and man
+pages like:
+
+```sh
+make uninstall
+```
+
+as either root or via sudo.
+
+If you installed with a different `PREFIX` make sure to specify that. For
+instance if you used `PREFIX=/usr` do instead:
+
+```sh
+make PREFIX=/usr uninstall
+```
+
+as either root or via sudo.
 
 
 # The dbg API


### PR DESCRIPTION
Add to the Makefile the PREFIX variable so one can change the install location from the default /usr/local. For instance to use /usr:

    make PREFIX=/usr install

Added uninstall rule to uninstall the programs, library and man pages. If one specified a different PREFIX in install they would have to specify it for uninstall too like:

    make PREFIX=/usr uninstall

To be congruent with install, the uninstall allows one to silence the rm verbosity (RM_V variable instead of INSTALL_V variable).

Updated README.md file for the above changes (well not the RM_V part).