### PR TITLE
Clarify slightly a comment in dbg_example.c

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .DS_Store
 ._.DS_Store
 /Makefile.local
+/Makefile.orig
 NOTES
 *.[ao]
 *.dSYM/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *~
 .DS_Store
+._.DS_Store
 /Makefile.local
 NOTES
 *.[ao]

--- a/Makefile
+++ b/Makefile
@@ -383,12 +383,12 @@ dbg.o: dbg.c
 	${CC} ${CFLAGS} dbg.c -c
 
 libdbg.a: ${LIB_OBJS}
-	${RM} -f $@
+	${Q} ${RM} ${RM_V} -f $@
 	${AR} -r -u -v $@ $^
 	${RANLIB} $@
 
 dbg_test.c: dbg.c
-	${RM} -f $@
+	${Q} ${RM} ${RM_V} -f $@
 	${CP} -v -f dbg.c $@
 
 dbg_test.o: dbg_test.c
@@ -461,7 +461,7 @@ test:
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
-	${Q} ${RM} -f dbg_test.out
+	${Q} ${RM} ${RM_V} -f dbg_test.out
 	${Q} if [[ ! -x ./dbg_test ]]; then \
 	    echo "${OUR_NAME}: ERROR: executable not found: ./dbg_test" 1>&2; \
 	    echo "${OUR_NAME}: ERROR: unable to perform complete test" 1>&2; \
@@ -616,7 +616,7 @@ local_dir_tags: ${ALL_CSRC} ${ALL_HSRC}
 	    echo ''; 1>&2; \
 	    exit 1; \
 	fi
-	${Q} ${RM} -f ${LOCAL_DIR_TAGS}
+	${Q} ${RM} ${RM_V} -f ${LOCAL_DIR_TAGS}
 	-${E} ${CTAGS} -w -f ${LOCAL_DIR_TAGS} ${ALL_CSRC} ${ALL_HSRC}
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"
@@ -627,7 +627,7 @@ all_tags:
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
-	${E} ${RM} -f tags
+	${Q} ${RM} ${RM_V} -f tags
 	${E} ${CP} -f -v ${LOCAL_DIR_TAGS} tags
 	${E} ${SORT} tags -o tags
 	${S} echo
@@ -645,7 +645,7 @@ legacy_clobber: legacy_clean
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
-	${E} ${RM} -f dbg.a
+	${Q} ${RM} ${RM_V} -f dbg.a
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"
 
@@ -661,8 +661,8 @@ clean:
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
-	${RM} -f ${ALL_OBJS} ${ALL_BUILT_SRC}
-	${RM} -f dbg_test.out
+	${Q} ${RM} ${RM_V} -f ${ALL_OBJS} ${ALL_BUILT_SRC}
+	${Q} ${RM} ${RM_V} -f dbg_test.out
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"
 
@@ -670,9 +670,9 @@ clobber: legacy_clobber clean
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
-	${RM} -f ${TARGETS}
-	${RM} -f tags ${LOCAL_DIR_TAGS}
-	${E} ${RM} -f Makefile.orig 
+	${Q} ${RM} ${RM_V} -f ${TARGETS}
+	${Q} ${RM} ${RM_V} -f tags ${LOCAL_DIR_TAGS}
+	${Q} ${RM} ${RM_V} -f Makefile.orig 
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"
 
@@ -682,7 +682,7 @@ install: all install_man
 	${S} echo
 	${I} ${INSTALL} ${INSTALL_V} -d -m 0775 ${DEST_LIB}
 	${I} ${INSTALL} ${INSTALL_V} -m 0444 ${LIBA_TARGETS} ${DEST_LIB}
-	${I} ${RM} -f ${DEST_LIB}/`echo ${LIBA_TARGETS} | ${SED} -e 's/^lib//'`
+	${Q} ${RM} ${RM_V} -f ${DEST_LIB}/`echo ${LIBA_TARGETS} | ${SED} -e 's/^lib//'`
 	${I} ${LN} -s ${LIBA_TARGETS} ${DEST_LIB}/`echo ${LIBA_TARGETS} | ${SED} -e 's/^lib//'`
 	${I} ${INSTALL} ${INSTALL_V} -d -m 0775 ${DEST_INCLUDE}
 	${I} ${INSTALL} ${INSTALL_V} -m 0444 ${H_SRC_TARGETS} ${DEST_INCLUDE}
@@ -695,62 +695,62 @@ uninstall:
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
-	${I} ${RM} -f ${RM_V} ${DEST_LIB}/libdbg.a
-	${I} ${RM} -f ${RM_V} ${DEST_LIB}/dbg.a
-	${I} ${RM} -f ${RM_V} ${DEST_DIR}/dbg_example
-	${I} ${RM} -f ${RM_V} ${DEST_DIR}/dbg_test
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/dbg.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/err.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/msg.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/warn.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/werr.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/printf_usage.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/warn_or_err.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/errp.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/fdbg.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/ferr.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/ferrp.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/fmsg.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/fprintf_usage.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/fwarn.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/fwarn_or_err.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/fwarnp.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/fwerr.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/fwerrp.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/sndbg.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/snmsg.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/snwarn.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/snwarnp.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/snwerr.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/snwerrp.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/vdbg.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/verr.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/verrp.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/vfdbg.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/vferr.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/vferrp.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/vfmsg.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/vfprintf_usage.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/vfwarn.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/vfwarn_or_err.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/vfwarnp.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/vfwerr.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/vfwerrp.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/vmsg.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/vprintf_usage.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/vsndbg.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/vsnmsg.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/vsnwarn.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/vsnwarnp.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/vsnwerr.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/vsnwerrp.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/vwarn.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/vwarn_or_err.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/vwarnp.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/vwerr.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/vwerrp.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/warnp.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/werrp.3
+	${Q} ${RM} ${RM_V} -f ${DEST_LIB}/libdbg.a
+	${Q} ${RM} ${RM_V} -f ${DEST_LIB}/dbg.a
+	${Q} ${RM} ${RM_V} -f ${DEST_DIR}/dbg_example
+	${Q} ${RM} ${RM_V} -f ${DEST_DIR}/dbg_test
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/dbg.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/err.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/msg.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/warn.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/werr.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/printf_usage.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/warn_or_err.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/errp.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/fdbg.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/ferr.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/ferrp.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/fmsg.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/fprintf_usage.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/fwarn.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/fwarn_or_err.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/fwarnp.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/fwerr.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/fwerrp.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/sndbg.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/snmsg.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/snwarn.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/snwarnp.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/snwerr.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/snwerrp.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/vdbg.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/verr.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/verrp.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/vfdbg.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/vferr.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/vferrp.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/vfmsg.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/vfprintf_usage.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/vfwarn.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/vfwarn_or_err.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/vfwarnp.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/vfwerr.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/vfwerrp.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/vmsg.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/vprintf_usage.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/vsndbg.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/vsnmsg.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/vsnwarn.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/vsnwarnp.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/vsnwerr.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/vsnwerrp.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/vwarn.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/vwarn_or_err.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/vwarnp.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/vwerr.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/vwerrp.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/warnp.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/werrp.3
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"
 

--- a/Makefile
+++ b/Makefile
@@ -672,6 +672,7 @@ clobber: legacy_clobber clean
 	${S} echo
 	${RM} -f ${TARGETS}
 	${RM} -f tags ${LOCAL_DIR_TAGS}
+	${E} ${RM} -f Makefile.orig 
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"
 

--- a/dbg_example.c
+++ b/dbg_example.c
@@ -1,8 +1,8 @@
 /*
  * dbg_example.c - trivial demo
  *
- * This is just a trivial demo for the dbg API.  See the main function in dbg.c
- * for a more complete example.
+ * This is just a trivial demo for the dbg API.  See the main() function in
+ * dbg.c for a more complete example.
  *
  * Written in 2022 by:
  *

--- a/man/man3/dbg.3
+++ b/man/man3/dbg.3
@@ -228,8 +228,8 @@ All functions output extra newlines to help let the messages stand out better.
 .nf
 $ cat dbg_example.c
 /*
- * This is just a trivial demo for the dbg api, see the main function in dbg.c
- * for a better example.
+ * This is just a trivial demo for the dbg api, see the main() function in
+ * dbg.c for a better example.
  */
 
 #include "dbg.h"


### PR DESCRIPTION

I should have put () after main to make it clearer that the function to
check is not the main function of the API (in the sense of the main
function of the file which could be interpreted as dbg(), unlikely as
that seems) but the actual main() function instead.

This was updated in the dbg.3 man page too as that example is there (it 
is useful to have it in the man page since make install does not install
dbg_example.c but it does install the man pages).