### PR TITLE
Make RM_V empty by default

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,66 @@
+name: Bug report
+description: Report a bug
+title: "Bug: <bug title>"
+labels: ["bug"]
+body:
+- type: checkboxes
+  attributes:
+    label: Is there an existing issue for this?
+    description: Please search to see if an issue already exists for the problem you're reporting.
+    options:
+    - label: I have searched for existing issues and did not find anything like this
+      required: true
+- type: textarea
+  attributes:
+    label: Describe the bug
+    description: Please give a **clear** and **concise** description of what the bug is.
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: What you expect
+    description: |
+        Please describe what you think it should be instead and why, as best you can (the more details you provide the better).
+
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: Environment
+    description: |
+      Example:
+        - **OS**: macOS Sonoma 14.5
+        - **Device**: MacBook Pro M1
+        - **Compiler**: Apple clang version 15.0.0 (clang-1500.3.9.4)
+
+        **PLEASE** provide **AT** **LEAST** the above items. If you have the **SAME** problem with more than one device please list the above for **ALL** **RELEVANT** **devices** with **any** **relevant** **context**.
+    value: |
+        - OS:
+        - Device:
+        - Compiler:
+    render: markdown
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: bug_report.sh output
+    description: |
+      Please attach the log file of './bug_report.sh' as well as anything else you think might be useful.
+
+      Tip: you can attach files by clicking the text area to highlight it and then click the link that says paste, drop or click to add files.
+  validations:
+    required: false
+
+- type: textarea
+  attributes:
+    label: Anything else?
+    description: |
+      Do you have any additional context or information that might be helpful? Please let us know!
+
+      Tip: you can attach files by clicking the text area to highlight it and then click the link that says paste, drop or click to add files.
+  validations:
+    required: false
+

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,47 @@
+name: Enhancement
+description: Suggest an enhancement
+title: "Enhancement: <enhancement title>"
+labels: ["enhancement"]
+body:
+- type: checkboxes
+  attributes:
+    label: Is there an existing issue for this?
+    description: Please search to see if an issue already exists for the feature you're suggesting.
+    options:
+    - label: I have searched for existing issues and did not find anything like this
+      required: true
+
+- type: textarea
+  attributes:
+    label: Describe the enhancement
+    description: |
+        Please describe the enhancement and why, as best you can (the more details you provide the better).
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: Relevant images, screenshots or other files
+    description: |
+       If you have images or other files that will help explain what you're getting at, this can also be **EXTREMELY** helpful.
+
+       Tip: you can attach files by clicking the text area to highlight it and then click the link that says paste, drop or click to add files.
+  validations:
+    required: false
+
+- type: textarea
+  attributes:
+    label: Relevant links
+    description: Please provide us with a list of relevant links, if applicable.
+  validations:
+    required: false
+
+- type: textarea
+  attributes:
+    label: Anything else?
+    description: |
+      Do you have any additional context or information? Please let us know!
+
+  validations:
+    required: false
+

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,47 @@
+name: Feature request
+description: Suggest a feature
+title: "Feature: <feature title>"
+labels: ["Feature"]
+body:
+- type: checkboxes
+  attributes:
+    label: Is there an existing issue for this?
+    description: Please search to see if an issue already exists for the feature you're suggesting.
+    options:
+    - label: I have searched for existing issues and did not find anything like this
+      required: true
+
+- type: textarea
+  attributes:
+    label: Describe the feature
+    description: |
+        Please describe the feature you would like to have and why, as best you can (the more details you provide the better).
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: Relevant images, screenshots or other files
+    description: |
+       If you have images or other files that will help explain what you're getting at, this can also be **EXTREMELY** helpful.
+
+       Tip: you can attach files by clicking the text area to highlight it and then click the link that says paste, drop or click to add files.
+  validations:
+    required: false
+
+- type: textarea
+  attributes:
+    label: Relevant links
+    description: Please provide us with a list of relevant links, if applicable.
+  validations:
+    required: false
+
+- type: textarea
+  attributes:
+    label: Anything else?
+    description: |
+      Do you have any additional context or information? Please let us know!
+
+  validations:
+    required: false
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,3 +37,5 @@ jobs:
       run: make picky
     - name: make check_man
       run: make check_man
+    - name: make depend
+      run: make depend

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .DS_Store
 ._.DS_Store
 /Makefile.local
+/Makefile.orig
 NOTES
 *.[ao]
 *.dSYM/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *~
 .DS_Store
+._.DS_Store
 /Makefile.local
 NOTES
 *.[ao]

--- a/Makefile
+++ b/Makefile
@@ -383,12 +383,12 @@ dbg.o: dbg.c
 	${CC} ${CFLAGS} dbg.c -c
 
 libdbg.a: ${LIB_OBJS}
-	${RM} -f $@
+	${Q} ${RM} ${RM_V} -f $@
 	${AR} -r -u -v $@ $^
 	${RANLIB} $@
 
 dbg_test.c: dbg.c
-	${RM} -f $@
+	${Q} ${RM} ${RM_V} -f $@
 	${CP} -v -f dbg.c $@
 
 dbg_test.o: dbg_test.c
@@ -461,7 +461,7 @@ test:
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
-	${Q} ${RM} -f dbg_test.out
+	${Q} ${RM} ${RM_V} -f dbg_test.out
 	${Q} if [[ ! -x ./dbg_test ]]; then \
 	    echo "${OUR_NAME}: ERROR: executable not found: ./dbg_test" 1>&2; \
 	    echo "${OUR_NAME}: ERROR: unable to perform complete test" 1>&2; \
@@ -616,7 +616,7 @@ local_dir_tags: ${ALL_CSRC} ${ALL_HSRC}
 	    echo ''; 1>&2; \
 	    exit 1; \
 	fi
-	${Q} ${RM} -f ${LOCAL_DIR_TAGS}
+	${Q} ${RM} ${RM_V} -f ${LOCAL_DIR_TAGS}
 	-${E} ${CTAGS} -w -f ${LOCAL_DIR_TAGS} ${ALL_CSRC} ${ALL_HSRC}
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"
@@ -627,7 +627,7 @@ all_tags:
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
-	${E} ${RM} -f tags
+	${Q} ${RM} ${RM_V} -f tags
 	${E} ${CP} -f -v ${LOCAL_DIR_TAGS} tags
 	${E} ${SORT} tags -o tags
 	${S} echo
@@ -645,7 +645,7 @@ legacy_clobber: legacy_clean
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
-	${E} ${RM} -f dbg.a
+	${Q} ${RM} ${RM_V} -f dbg.a
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"
 
@@ -661,8 +661,8 @@ clean:
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
-	${RM} -f ${ALL_OBJS} ${ALL_BUILT_SRC}
-	${RM} -f dbg_test.out
+	${Q} ${RM} ${RM_V} -f ${ALL_OBJS} ${ALL_BUILT_SRC}
+	${Q} ${RM} ${RM_V} -f dbg_test.out
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"
 
@@ -670,9 +670,9 @@ clobber: legacy_clobber clean
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
-	${RM} -f ${TARGETS}
-	${RM} -f tags ${LOCAL_DIR_TAGS}
-	${E} ${RM} -f Makefile.orig 
+	${Q} ${RM} ${RM_V} -f ${TARGETS}
+	${Q} ${RM} ${RM_V} -f tags ${LOCAL_DIR_TAGS}
+	${Q} ${RM} ${RM_V} -f Makefile.orig 
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"
 
@@ -682,7 +682,7 @@ install: all install_man
 	${S} echo
 	${I} ${INSTALL} ${INSTALL_V} -d -m 0775 ${DEST_LIB}
 	${I} ${INSTALL} ${INSTALL_V} -m 0444 ${LIBA_TARGETS} ${DEST_LIB}
-	${I} ${RM} -f ${DEST_LIB}/`echo ${LIBA_TARGETS} | ${SED} -e 's/^lib//'`
+	${Q} ${RM} ${RM_V} -f ${DEST_LIB}/`echo ${LIBA_TARGETS} | ${SED} -e 's/^lib//'`
 	${I} ${LN} -s ${LIBA_TARGETS} ${DEST_LIB}/`echo ${LIBA_TARGETS} | ${SED} -e 's/^lib//'`
 	${I} ${INSTALL} ${INSTALL_V} -d -m 0775 ${DEST_INCLUDE}
 	${I} ${INSTALL} ${INSTALL_V} -m 0444 ${H_SRC_TARGETS} ${DEST_INCLUDE}
@@ -695,62 +695,62 @@ uninstall:
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ starting"
 	${S} echo
-	${I} ${RM} -f ${RM_V} ${DEST_LIB}/libdbg.a
-	${I} ${RM} -f ${RM_V} ${DEST_LIB}/dbg.a
-	${I} ${RM} -f ${RM_V} ${DEST_DIR}/dbg_example
-	${I} ${RM} -f ${RM_V} ${DEST_DIR}/dbg_test
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/dbg.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/err.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/msg.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/warn.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/werr.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/printf_usage.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/warn_or_err.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/errp.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/fdbg.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/ferr.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/ferrp.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/fmsg.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/fprintf_usage.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/fwarn.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/fwarn_or_err.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/fwarnp.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/fwerr.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/fwerrp.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/sndbg.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/snmsg.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/snwarn.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/snwarnp.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/snwerr.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/snwerrp.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/vdbg.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/verr.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/verrp.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/vfdbg.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/vferr.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/vferrp.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/vfmsg.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/vfprintf_usage.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/vfwarn.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/vfwarn_or_err.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/vfwarnp.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/vfwerr.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/vfwerrp.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/vmsg.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/vprintf_usage.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/vsndbg.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/vsnmsg.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/vsnwarn.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/vsnwarnp.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/vsnwerr.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/vsnwerrp.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/vwarn.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/vwarn_or_err.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/vwarnp.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/vwerr.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/vwerrp.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/warnp.3
-	${I} ${RM} -f ${RM_V} ${MAN3_DIR}/werrp.3
+	${Q} ${RM} ${RM_V} -f ${DEST_LIB}/libdbg.a
+	${Q} ${RM} ${RM_V} -f ${DEST_LIB}/dbg.a
+	${Q} ${RM} ${RM_V} -f ${DEST_DIR}/dbg_example
+	${Q} ${RM} ${RM_V} -f ${DEST_DIR}/dbg_test
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/dbg.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/err.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/msg.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/warn.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/werr.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/printf_usage.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/warn_or_err.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/errp.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/fdbg.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/ferr.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/ferrp.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/fmsg.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/fprintf_usage.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/fwarn.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/fwarn_or_err.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/fwarnp.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/fwerr.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/fwerrp.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/sndbg.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/snmsg.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/snwarn.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/snwarnp.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/snwerr.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/snwerrp.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/vdbg.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/verr.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/verrp.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/vfdbg.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/vferr.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/vferrp.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/vfmsg.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/vfprintf_usage.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/vfwarn.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/vfwarn_or_err.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/vfwarnp.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/vfwerr.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/vfwerrp.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/vmsg.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/vprintf_usage.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/vsndbg.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/vsnmsg.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/vsnwarn.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/vsnwarnp.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/vsnwerr.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/vsnwerrp.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/vwarn.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/vwarn_or_err.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/vwarnp.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/vwerr.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/vwerrp.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/warnp.3
+	${Q} ${RM} ${RM_V} -f ${MAN3_DIR}/werrp.3
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"
 

--- a/Makefile
+++ b/Makefile
@@ -672,6 +672,7 @@ clobber: legacy_clobber clean
 	${S} echo
 	${RM} -f ${TARGETS}
 	${RM} -f tags ${LOCAL_DIR_TAGS}
+	${E} ${RM} -f Makefile.orig 
 	${S} echo
 	${S} echo "${OUR_NAME}: make $@ ending"
 

--- a/Makefile
+++ b/Makefile
@@ -132,8 +132,8 @@ PREFIX= /usr/local
 # RM_V=					rm w/o -v flag (quiet mode)
 # RM_V= -v				rm with -v (debug / verbose mode)
 #
-#RM_V=
-RM_V= -v
+#RM_V= -v
+RM_V=
 
 # Additional controls
 #

--- a/dbg_example.c
+++ b/dbg_example.c
@@ -1,8 +1,8 @@
 /*
  * dbg_example.c - trivial demo
  *
- * This is just a trivial demo for the dbg API.  See the main function in dbg.c
- * for a more complete example.
+ * This is just a trivial demo for the dbg API.  See the main() function in
+ * dbg.c for a more complete example.
  *
  * Written in 2022 by:
  *

--- a/man/man3/dbg.3
+++ b/man/man3/dbg.3
@@ -228,8 +228,8 @@ All functions output extra newlines to help let the messages stand out better.
 .nf
 $ cat dbg_example.c
 /*
- * This is just a trivial demo for the dbg api, see the main function in dbg.c
- * for a better example.
+ * This is just a trivial demo for the dbg api, see the main() function in
+ * dbg.c for a better example.
  */
 
 #include "dbg.h"


### PR DESCRIPTION

This is because in the past it rm was not used with -v.