### PR TITLE
Improve Makefile, add verbosity to make test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,8 +31,8 @@ jobs:
       run: make all
     - name: make
       run: make
-    - name: make test
-      run: make test
+    - name: make VERBOSITY=7 test
+      run: make VERBOSITY=7 test
     - name: make picky
       run: make picky
     - name: make check_man

--- a/Makefile
+++ b/Makefile
@@ -96,9 +96,9 @@ E=
 # else -v 1
 #
 ifeq ($(strip ${Q}),@)
-Q_V_OPTION="0"
+VERBOSITY="0"
 else
-Q_V_OPTION="1"
+VERBOSITY="1"
 endif
 
 # I= @					do not echo install commands (quiet mode)
@@ -467,8 +467,8 @@ test:
 	    echo "${OUR_NAME}: ERROR: unable to perform complete test" 1>&2; \
 	    exit 1; \
 	else \
-	    echo "./dbg_test -e 2 foo bar baz >dbg_test.out 2>&1"; \
-	    ./dbg_test -v 1 -e 2 foo bar baz >dbg_test.out 2>&1; \
+	    echo "./dbg_test ${VERBOSITY} -e 2 foo bar baz >dbg_test.out 2>&1"; \
+	    ./dbg_test -v ${VERBOSITY} -e 2 foo bar baz >dbg_test.out 2>&1; \
 	    EXIT_CODE="$$?"; \
 	    if [[ $$EXIT_CODE -ne 5 ]]; then \
 		echo "${OUR_NAME}: exit status of dbg_test: $$EXIT_CODE != 5"; \


### PR DESCRIPTION
Rename Q_V_OPTION to 'VERBOSITY' in Makefile for easier use.

Update GitHub workflow test file to use make VERBOSITY=7 test. The dbg_test.c uses fdbg() (on stderr) but the make test rule writes to an output file that then is validated so the make test with verbosity does not do much currently but it allows for one to do more if is desired.