### PR TITLE
Disable install -v by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ I=
 # INSTALL_V= -v				install with -v (debug / verbose mode
 #
 #INSTALL_V=
-INSTALL_V= -v
+INSTALL_V=
 
 # where to install
 #


### PR DESCRIPTION
To be more portable don't use install -v in install rule by default. If one needs that they can do:

    make INSTALL_V=-v install