### PR TITLE
Disable -g3 in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,8 +170,8 @@ C_STD= -std=gnu17
 
 # optimization and debug level
 #
-C_OPT= -O3 -g3
-#C_OPT= -O0 -g
+C_OPT= -O3
+#C_OPT= -O0 -g3
 
 # Compiler warnings
 #


### PR DESCRIPTION
The use of -O3 with debug symbols is problematic because by optimising the code it makes it harder to debug even with debug symbols generated (-g option). If one needs to have debug symbols they should do something like:

    make C_OPT=-g3

and not have the -O3 (they could use -O0 instead of course).